### PR TITLE
docs: improve basic Drawer example to look like the render

### DIFF
--- a/web/src/examples/primitives/drawer/basic/css/index.css
+++ b/web/src/examples/primitives/drawer/basic/css/index.css
@@ -1,4 +1,6 @@
 [data-corvu-drawer-trigger] {
+  border-width: 0;
+  cursor: pointer;
   margin-top: auto;
   margin-bottom: auto;
   border-radius: 0.5rem;
@@ -37,6 +39,9 @@
 }
 
 [data-corvu-drawer-content] {
+  box-sizing: border-box;
+  border-width: 0;
+  border-style: solid;
   position: fixed;
   left: 0px;
   right: 0px;
@@ -46,30 +51,22 @@
   height: 100%;
   max-height: 500px;
   flex-direction: column;
-  border-style: solid;
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
   border-top-width: 4px;
-  border-left: none;
-  border-right: none;
-  border-bottom: none;
   border-color: hsl(258, 79%, 74%);
-  background-color: hsl(253, 26.4%, 17.1%);
-  color: hsl(266, 41%, 90%);
+  background-color: hsl(249, 87%, 94%);
   padding-top: 0.75rem;
-  -webkit-user-select: none;
-  user-select: none;
 }
 
 [data-corvu-drawer-content]::after {
-  content: '';
   position: absolute;
   left: 0px;
   right: 0px;
   top: 100%;
   height: 50%;
   background-color: inherit;
-  border: none;
+  content: '';
 }
 
 [data-corvu-drawer-content][data-transitioning] {
@@ -78,8 +75,14 @@
   transition-duration: 500ms;
 }
 
+@media (min-width: 768px) {
+  [data-corvu-drawer-content] {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+}
+
 .notch {
-  margin-top: 0.5rem;
   height: 0.25rem;
   width: 2.5rem;
   align-self: center;
@@ -89,7 +92,7 @@
 
 [data-corvu-drawer-label] {
   margin-top: 0.5rem;
-  margin-bottom: 0;
+  margin-bottom: 0px;
   text-align: center;
   font-size: 1.25rem;
   line-height: 1.75rem;
@@ -105,7 +108,8 @@
   position: absolute;
   left: 0px;
   right: 0px;
-  bottom: -2.25rem;
+  bottom: -1.25rem;
   z-index: 10;
   text-align: center;
+  margin: 0px;
 }

--- a/web/src/examples/primitives/drawer/basic/css/index.css
+++ b/web/src/examples/primitives/drawer/basic/css/index.css
@@ -12,7 +12,6 @@
   font-weight: 500;
   transition-property: all;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
   transition-duration: 100ms;
   animation-duration: 100ms;
 }
@@ -47,21 +46,30 @@
   height: 100%;
   max-height: 500px;
   flex-direction: column;
+  border-style: solid;
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
   border-top-width: 4px;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
   border-color: hsl(258, 79%, 74%);
-  background-color: hsl(249, 87%, 94%);
+  background-color: hsl(253, 26.4%, 17.1%);
+  color: hsl(266, 41%, 90%);
   padding-top: 0.75rem;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 [data-corvu-drawer-content]::after {
+  content: '';
   position: absolute;
   left: 0px;
   right: 0px;
   top: 100%;
   height: 50%;
   background-color: inherit;
+  border: none;
 }
 
 [data-corvu-drawer-content][data-transitioning] {
@@ -70,24 +78,18 @@
   transition-duration: 500ms;
 }
 
-@media (min-width: 1024px) {
-  [data-corvu-drawer-content] {
-    -webkit-user-select: none;
-    user-select: none;
-  }
-}
-
 .notch {
   margin-top: 0.5rem;
   height: 0.25rem;
   width: 2.5rem;
   align-self: center;
   border-radius: 9999px;
-  background-color: TOOD;
+  background-color: hsl(258, 79%, 74%);
 }
 
 [data-corvu-drawer-label] {
   margin-top: 0.5rem;
+  margin-bottom: 0;
   text-align: center;
   font-size: 1.25rem;
   line-height: 1.75rem;
@@ -95,7 +97,7 @@
 }
 
 [data-corvu-drawer-description] {
-  margin-top: 1rem;
+  margin-top: 0.25rem;
   text-align: center;
 }
 
@@ -103,7 +105,7 @@
   position: absolute;
   left: 0px;
   right: 0px;
-  bottom: -1.25rem;
+  bottom: -2.25rem;
   z-index: 10;
   text-align: center;
 }


### PR DESCRIPTION
This PR make some changes to the css in the basic Drawer example.

The original code, when copy/pasted into an IDE/StackBlitz, didn't render like the example present in the docs website.

This is how it should render:
<img width="1440" alt="Captura de Tela 2024-05-22 às 21 07 43" src="https://github.com/corvudev/corvu/assets/15372719/37c6a198-170e-4d24-b062-f2faff8f758a">

And this is how it was rendering:
<img width="1440" alt="Captura de Tela 2024-05-22 às 21 12 07" src="https://github.com/corvudev/corvu/assets/15372719/ea298fc9-5657-4f45-9534-e3eb3266c879">


Let me know if any changes are needed =)