### PR TITLE
feat: move the calendar to @internationalized/date add other calendar types support.

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -72,6 +72,7 @@
     "typescript-eslint": "^8.31.1"
   },
   "peerDependencies": {
-    "solid-js": "^1.8"
+    "solid-js": "^1.8",
+    "@internationalized/date": ">=3.0.0"
   }
 }

--- a/packages/calendar/src/Nav.tsx
+++ b/packages/calendar/src/Nav.tsx
@@ -12,13 +12,16 @@ import {
   type DynamicButtonSharedElementProps,
   type DynamicProps,
 } from '@corvu/utils/dynamic'
+import type { DateValue } from '@internationalized/date'
 import { useInternalCalendarContext } from '@src/context'
 
 export type CalendarNavCorvuProps = {
   /**
    * The action to perform when pressing this navigation button.
    */
-  action: `${'prev' | 'next'}-${'month' | 'year'}` | ((date: Date) => Date)
+  action:
+    | `${'prev' | 'next'}-${'month' | 'year'}`
+    | ((date: DateValue) => DateValue)
   /**
    * The `id` of the calendar context to use.
    */

--- a/packages/calendar/src/context.ts
+++ b/packages/calendar/src/context.ts
@@ -5,11 +5,11 @@ import {
   type Setter,
   useContext,
 } from 'solid-js'
+import type { Calendar, DateValue } from '@internationalized/date'
 import {
   createKeyedContext,
   useKeyedContext,
 } from '@corvu/utils/create/keyedContext'
-import type { DateValue } from '@internationalized/date'
 
 export type CalendarContextValue<
   Mode extends 'single' | 'multiple' | 'range' =
@@ -97,6 +97,12 @@ export type CalendarContextBaseValue = {
   focusedDayRef: Accessor<HTMLElement | null>
   /** The `id` attributes of the calendar label elements. Can be undefined if no `Calendar.Label` is present for the given month index. */
   labelIds: Accessor<Accessor<string | undefined>[]>
+  /** The `timeZone` of the calendar */
+  timeZone?: string
+  /** The `locale` of the current user */
+  locale?: string
+  /** The calendar type */
+  calendar?: Calendar
 }
 
 const CalendarContext = createContext<CalendarContextValue>()
@@ -153,6 +159,7 @@ type InternalCalendarContextValue = CalendarContextValue & {
   disabled: (day: DateValue) => boolean
   setFocusedDayRef: Setter<HTMLElement | null>
   timeZone: string
+  calendar: Calendar
 }
 
 const InternalCalendarContext = createContext<InternalCalendarContextValue>()

--- a/packages/calendar/src/context.ts
+++ b/packages/calendar/src/context.ts
@@ -9,6 +9,7 @@ import {
   createKeyedContext,
   useKeyedContext,
 } from '@corvu/utils/create/keyedContext'
+import type { DateValue } from '@internationalized/date'
 
 export type CalendarContextValue<
   Mode extends 'single' | 'multiple' | 'range' =
@@ -30,18 +31,18 @@ export type CalendarContextSingleValue = {
   /** The mode of the calendar. */
   mode: Accessor<'single'>
   /** The value of the calendar. */
-  value: Accessor<Date | null>
+  value: Accessor<DateValue | null>
   /** Setter to change the value of the calendar. */
-  setValue: Setter<Date | null>
+  setValue: Setter<DateValue | null>
 } & CalendarContextBaseValue
 
 export type CalendarContextMultipleValue = {
   /** The mode of the calendar. */
   mode: Accessor<'multiple'>
   /** The value of the calendar. */
-  value: Accessor<Date[]>
+  value: Accessor<DateValue[]>
   /** Setter to change the value of the calendar. */
-  setValue: Setter<Date[]>
+  setValue: Setter<DateValue[]>
   /** The minimum number of days that have to be selected. */
   min: Accessor<number | null>
   /** The maximum number of days that can be selected. */
@@ -52,22 +53,22 @@ export type CalendarContextRangeValue = {
   /** The mode of the calendar. */
   mode: Accessor<'range'>
   /** The value of the calendar. */
-  value: Accessor<{ from: Date | null; to: Date | null }>
+  value: Accessor<{ from: DateValue | null; to: DateValue | null }>
   /** Setter to change the value of the calendar. */
-  setValue: Setter<{ from: Date | null; to: Date | null }>
+  setValue: Setter<{ from: DateValue | null; to: DateValue | null }>
   /** Whether to reset the range selection if a disabled day is included in the range. */
   excludeDisabled: Accessor<boolean>
 } & CalendarContextBaseValue
 
 export type CalendarContextBaseValue = {
   /** The month to display in the calendar. Is always the first month if multiple months are displayed. */
-  month: Accessor<Date>
+  month: Accessor<DateValue>
   /** Setter to change the month to display in the calendar. Automatically adjusts the focusedDay to be within the visible range. */
-  setMonth: Setter<Date>
+  setMonth: Setter<DateValue>
   /** The day that is currently focused in the calendar grid. */
-  focusedDay: Accessor<Date>
+  focusedDay: Accessor<DateValue>
   /** Setter to change the focused day in the calendar grid. Automatically adjusts the month to ensure the focused day is visible. */
-  setFocusedDay: Setter<Date>
+  setFocusedDay: Setter<DateValue>
   /** The first day of the week. (0-6, 0 is Sunday) */
   startOfWeek: Accessor<number>
   /** Whether the value is required. Prevents unselecting the value. */
@@ -81,14 +82,16 @@ export type CalendarContextBaseValue = {
   /** The text direction of the calendar. */
   textDirection: Accessor<'ltr' | 'rtl'>
   /** Array of weekdays starting from the first day of the week. */
-  weekdays: Accessor<Date[]>
+  weekdays: Accessor<DateValue[]>
   /** Array of the currently displayed months. */
-  months: Accessor<{ month: Date; weeks: Date[][] }[]>
+  months: Accessor<{ month: DateValue; weeks: DateValue[][] }[]>
   /** Function to get the weeks of the current month. Useful if only one month is being rendered. */
-  weeks: Accessor<Date[][]>
+  weeks: Accessor<DateValue[][]>
   /** Function to navigate the calendar. */
   navigate: (
-    action: `${'prev' | 'next'}-${'month' | 'year'}` | ((date: Date) => Date),
+    action:
+      | `${'prev' | 'next'}-${'month' | 'year'}`
+      | ((date: DateValue) => DateValue),
   ) => void
   /** The ref of the currently focused calendar cell trigger. */
   focusedDayRef: Accessor<HTMLElement | null>
@@ -142,13 +145,14 @@ export const useCalendarContext = <
 type InternalCalendarContextValue = CalendarContextValue & {
   registerLabelId: (index: number) => void
   unregisterLabelId: (index: number) => void
-  onDaySelect: (day: Date) => void
-  isSelected: (date: Date) => boolean
-  isDisabled: (date: Date, month?: Date) => boolean
+  onDaySelect: (day: DateValue) => void
+  isSelected: (date: DateValue) => boolean
+  isDisabled: (date: DateValue, month?: DateValue) => boolean
   isFocusing: Accessor<boolean>
   setIsFocusing: Setter<boolean>
-  disabled: (day: Date) => boolean
+  disabled: (day: DateValue) => boolean
   setFocusedDayRef: Setter<HTMLElement | null>
+  timeZone: string
 }
 
 const InternalCalendarContext = createContext<InternalCalendarContextValue>()

--- a/packages/calendar/src/utils.ts
+++ b/packages/calendar/src/utils.ts
@@ -1,6 +1,8 @@
 import {
+  type Calendar,
   type DateValue,
   endOfMonth,
+  GregorianCalendar,
   isEqualDay,
   isToday,
   startOfMonth,
@@ -85,6 +87,8 @@ const findAvailableDayInMonth = (
   return start
 }
 
+const defaultCalendar = new GregorianCalendar() as Calendar
+
 export {
   isSameDay,
   isSameDayOrBefore,
@@ -94,4 +98,5 @@ export {
   dayIsInMonth,
   findAvailableDayInMonth,
   isToday,
+  defaultCalendar,
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@corvu/utils':
         specifier: workspace:~
         version: link:../utils
+      '@internationalized/date':
+        specifier: '>=3.0.0'
+        version: 3.8.2
     devDependencies:
       '@typescript-eslint/parser':
         specifier: ^8.31.1
@@ -1690,6 +1693,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@internationalized/date@3.8.2':
+    resolution: {integrity: sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -5466,6 +5472,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.1':
     optional: true
+
+  '@internationalized/date@3.8.2':
+    dependencies:
+      '@swc/helpers': 0.5.17
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -58,4 +58,8 @@ export default defineConfig({
   vite: {
     plugins: [tailwind()],
   },
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
 })

--- a/web/src/examples/primitives/calendar/basic/css/index.tsx
+++ b/web/src/examples/primitives/calendar/basic/css/index.tsx
@@ -17,7 +17,12 @@ const CalendarExample: VoidComponent = () => {
                 <CaretLeft size="18" />
               </Calendar.Nav>
               <Calendar.Label>
-                {formatMonth(props.month)} {props.month.getFullYear()}
+                {formatMonth(
+                  props.month.toDate(
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                  ),
+                )}{' '}
+                {props.month.year}
               </Calendar.Label>
               <Calendar.Nav action="next-month" aria-label="Go to next month">
                 <CaretRight size="18" />
@@ -28,8 +33,18 @@ const CalendarExample: VoidComponent = () => {
                 <tr>
                   <Index each={props.weekdays}>
                     {(weekday) => (
-                      <Calendar.HeadCell abbr={formatWeekdayLong(weekday())}>
-                        {formatWeekdayShort(weekday())}
+                      <Calendar.HeadCell
+                        abbr={formatWeekdayLong(
+                          weekday().toDate(
+                            Intl.DateTimeFormat().resolvedOptions().timeZone,
+                          ),
+                        )}
+                      >
+                        {formatWeekdayShort(
+                          weekday().toDate(
+                            Intl.DateTimeFormat().resolvedOptions().timeZone,
+                          ),
+                        )}
                       </Calendar.HeadCell>
                     )}
                   </Index>
@@ -43,7 +58,7 @@ const CalendarExample: VoidComponent = () => {
                         {(day) => (
                           <Calendar.Cell>
                             <Calendar.CellTrigger day={day()}>
-                              {day().getDate()}
+                              {day().day}
                             </Calendar.CellTrigger>
                           </Calendar.Cell>
                         )}

--- a/web/src/examples/primitives/calendar/basic/tailwind/index.tsx
+++ b/web/src/examples/primitives/calendar/basic/tailwind/index.tsx
@@ -7,65 +7,80 @@ const CalendarExample: VoidComponent = () => {
   return (
     <div>
       <Calendar mode="single">
-        {(props) => (
-          <div class="my-4 rounded-md bg-corvu-100 p-3 shadow-md md:my-8">
-            <div class="flex items-center justify-between">
-              <Calendar.Nav
-                action="prev-month"
-                aria-label="Go to previous month"
-                class="size-7 rounded-sm bg-corvu-200/50 p-1.25 hover:bg-corvu-200"
-              >
-                <CaretLeft size="18" />
-              </Calendar.Nav>
-              <Calendar.Label class="text-sm">
-                {formatMonth(props.month)} {props.month.getFullYear()}
-              </Calendar.Label>
-              <Calendar.Nav
-                action="next-month"
-                aria-label="Go to next month"
-                class="size-7 rounded-sm bg-corvu-200/50 p-1.25 hover:bg-corvu-200"
-              >
-                <CaretRight size="18" />
-              </Calendar.Nav>
-            </div>
-            <Calendar.Table class="mt-3">
-              <thead>
-                <tr>
-                  <Index each={props.weekdays}>
-                    {(weekday) => (
-                      <Calendar.HeadCell
-                        abbr={formatWeekdayLong(weekday())}
-                        class="w-8 pb-1 text-xs font-normal opacity-65"
-                      >
-                        {formatWeekdayShort(weekday())}
-                      </Calendar.HeadCell>
+        {(props) => {
+          return (
+            <div class="my-4 rounded-md bg-corvu-100 p-3 shadow-md md:my-8">
+              <div class="flex items-center justify-between">
+                <Calendar.Nav
+                  action="prev-month"
+                  aria-label="Go to previous month"
+                  class="size-7 rounded-sm bg-corvu-200/50 p-1.25 hover:bg-corvu-200"
+                >
+                  <CaretLeft size="18" />
+                </Calendar.Nav>
+                <Calendar.Label class="text-sm">
+                  {formatMonth(
+                    props.month.toDate(
+                      Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    ),
+                  )}{' '}
+                  {props.month.year}
+                </Calendar.Label>
+                <Calendar.Nav
+                  action="next-month"
+                  aria-label="Go to next month"
+                  class="size-7 rounded-sm bg-corvu-200/50 p-1.25 hover:bg-corvu-200"
+                >
+                  <CaretRight size="18" />
+                </Calendar.Nav>
+              </div>
+              <Calendar.Table class="mt-3">
+                <thead>
+                  <tr>
+                    <Index each={props.weekdays}>
+                      {(weekday) => (
+                        <Calendar.HeadCell
+                          abbr={formatWeekdayLong(
+                            weekday().toDate(
+                              Intl.DateTimeFormat().resolvedOptions().timeZone,
+                            ),
+                          )}
+                          class="w-8 pb-1 text-xs font-normal opacity-65"
+                        >
+                          {formatWeekdayShort(
+                            weekday().toDate(
+                              Intl.DateTimeFormat().resolvedOptions().timeZone,
+                            ),
+                          )}
+                        </Calendar.HeadCell>
+                      )}
+                    </Index>
+                  </tr>
+                </thead>
+                <tbody>
+                  <Index each={props.weeks}>
+                    {(week) => (
+                      <tr>
+                        <Index each={week()}>
+                          {(day) => (
+                            <Calendar.Cell class="p-0">
+                              <Calendar.CellTrigger
+                                day={day()}
+                                class="size-8 rounded-md text-sm focus-visible:bg-corvu-200/80 disabled:pointer-events-none disabled:opacity-40 data-selected:bg-corvu-300! data-today:bg-corvu-200/50 lg:hover:bg-corvu-200/80"
+                              >
+                                {day().day}
+                              </Calendar.CellTrigger>
+                            </Calendar.Cell>
+                          )}
+                        </Index>
+                      </tr>
                     )}
                   </Index>
-                </tr>
-              </thead>
-              <tbody>
-                <Index each={props.weeks}>
-                  {(week) => (
-                    <tr>
-                      <Index each={week()}>
-                        {(day) => (
-                          <Calendar.Cell class="p-0">
-                            <Calendar.CellTrigger
-                              day={day()}
-                              class="size-8 rounded-md text-sm focus-visible:bg-corvu-200/80 disabled:pointer-events-none disabled:opacity-40 data-selected:bg-corvu-300! data-today:bg-corvu-200/50 lg:hover:bg-corvu-200/80"
-                            >
-                              {day().getDate()}
-                            </Calendar.CellTrigger>
-                          </Calendar.Cell>
-                        )}
-                      </Index>
-                    </tr>
-                  )}
-                </Index>
-              </tbody>
-            </Calendar.Table>
-          </div>
-        )}
+                </tbody>
+              </Calendar.Table>
+            </div>
+          )
+        }}
       </Calendar>
     </div>
   )

--- a/web/src/examples/primitives/calendar/date-picker/tailwind/index.tsx
+++ b/web/src/examples/primitives/calendar/date-picker/tailwind/index.tsx
@@ -26,7 +26,13 @@ const CalendarExample: VoidComponent = () => {
           <Popover.Trigger class="my-auto flex w-56 items-center space-x-2 rounded-md bg-corvu-100 px-3 py-2 transition-all duration-100 hover:bg-corvu-200">
             <CalendarBlank size="20" />
             <Show when={props.value} fallback={<span>Pick a date</span>}>
-              <span>{formatTrigger(props.value!)}</span>
+              <span>
+                {formatTrigger(
+                  props.value!.toDate(
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                  ),
+                )}
+              </span>
             </Show>
           </Popover.Trigger>
           <Popover.Portal>
@@ -41,7 +47,12 @@ const CalendarExample: VoidComponent = () => {
                     <CaretLeft size="18" />
                   </Calendar.Nav>
                   <Calendar.Label as={Popover.Label} class="text-sm">
-                    {formatMonth(props.month)} {props.month.getFullYear()}
+                    {formatMonth(
+                      props.month.toDate(
+                        Intl.DateTimeFormat().resolvedOptions().timeZone,
+                      ),
+                    )}{' '}
+                    {props.month.year}
                   </Calendar.Label>
                   <Calendar.Nav
                     action="next-month"
@@ -57,10 +68,20 @@ const CalendarExample: VoidComponent = () => {
                       <Index each={props.weekdays}>
                         {(weekday) => (
                           <Calendar.HeadCell
-                            abbr={formatWeekdayLong(weekday())}
+                            abbr={formatWeekdayLong(
+                              weekday().toDate(
+                                Intl.DateTimeFormat().resolvedOptions()
+                                  .timeZone,
+                              ),
+                            )}
                             class="w-8 flex-1 pb-1 text-xs font-normal opacity-65"
                           >
-                            {formatWeekdayShort(weekday())}
+                            {formatWeekdayShort(
+                              weekday().toDate(
+                                Intl.DateTimeFormat().resolvedOptions()
+                                  .timeZone,
+                              ),
+                            )}
                           </Calendar.HeadCell>
                         )}
                       </Index>
@@ -77,7 +98,7 @@ const CalendarExample: VoidComponent = () => {
                                   day={day()}
                                   class="inline-flex size-8 items-center justify-center rounded-md text-sm focus-visible:bg-corvu-200/80 disabled:pointer-events-none disabled:opacity-40 data-selected:bg-corvu-300! data-today:bg-corvu-200/50 lg:hover:bg-corvu-200/80"
                                 >
-                                  {day().getDate()}
+                                  {day().day}
                                 </Calendar.CellTrigger>
                               </Calendar.Cell>
                             )}

--- a/web/src/examples/primitives/calendar/disabled/tailwind/index.tsx
+++ b/web/src/examples/primitives/calendar/disabled/tailwind/index.tsx
@@ -8,7 +8,7 @@ const CalendarExample: VoidComponent = () => {
     <div>
       <Calendar
         mode="single"
-        disabled={(day) => day.getDay() === 0 || day.getDay() === 6}
+        disabled={(day) => day.day === 0 || day.day === 6}
       >
         {(props) => (
           <div class="my-4 rounded-md bg-corvu-100 p-3 shadow-md md:my-8">
@@ -21,7 +21,12 @@ const CalendarExample: VoidComponent = () => {
                 <CaretLeft size="18" />
               </Calendar.Nav>
               <Calendar.Label class="text-sm">
-                {formatMonth(props.month)} {props.month.getFullYear()}
+                {formatMonth(
+                  props.month.toDate(
+                    Intl.DateTimeFormat().resolvedOptions().timeZone,
+                  ),
+                )}{' '}
+                {props.month.year}
               </Calendar.Label>
               <Calendar.Nav
                 action="next-month"
@@ -37,10 +42,18 @@ const CalendarExample: VoidComponent = () => {
                   <Index each={props.weekdays}>
                     {(weekday) => (
                       <Calendar.HeadCell
-                        abbr={formatWeekdayLong(weekday())}
+                        abbr={formatWeekdayLong(
+                          weekday().toDate(
+                            Intl.DateTimeFormat().resolvedOptions().timeZone,
+                          ),
+                        )}
                         class="w-8 flex-1 pb-1 text-xs font-normal opacity-65"
                       >
-                        {formatWeekdayShort(weekday())}
+                        {formatWeekdayShort(
+                          weekday().toDate(
+                            Intl.DateTimeFormat().resolvedOptions().timeZone,
+                          ),
+                        )}
                       </Calendar.HeadCell>
                     )}
                   </Index>
@@ -57,7 +70,7 @@ const CalendarExample: VoidComponent = () => {
                               day={day()}
                               class="inline-flex size-8 items-center justify-center rounded-md text-sm focus-visible:bg-corvu-200/80 disabled:pointer-events-none disabled:opacity-40 data-selected:bg-corvu-300! data-today:bg-corvu-200/50 lg:hover:bg-corvu-200/80"
                             >
-                              {day().getDate()}
+                              {day().day}
                             </Calendar.CellTrigger>
                           </Calendar.Cell>
                         )}

--- a/web/src/examples/primitives/calendar/range/tailwind/index.tsx
+++ b/web/src/examples/primitives/calendar/range/tailwind/index.tsx
@@ -29,8 +29,12 @@ const CalendarExample: VoidComponent = () => {
                   <div>
                     <div class="flex h-7 items-center justify-center">
                       <Calendar.Label index={index} class="text-sm">
-                        {formatMonth(month().month)}{' '}
-                        {month().month.getFullYear()}
+                        {formatMonth(
+                          month().month.toDate(
+                            Intl.DateTimeFormat().resolvedOptions().timeZone,
+                          ),
+                        )}{' '}
+                        {month().month.year}
                       </Calendar.Label>
                     </div>
                     <Calendar.Table index={index} class="mt-3">
@@ -39,10 +43,20 @@ const CalendarExample: VoidComponent = () => {
                           <Index each={props.weekdays}>
                             {(weekday) => (
                               <Calendar.HeadCell
-                                abbr={formatWeekdayLong(weekday())}
+                                abbr={formatWeekdayLong(
+                                  weekday().toDate(
+                                    Intl.DateTimeFormat().resolvedOptions()
+                                      .timeZone,
+                                  ),
+                                )}
                                 class="w-8 flex-1 pb-1 text-xs font-normal opacity-65"
                               >
-                                {formatWeekdayShort(weekday())}
+                                {formatWeekdayShort(
+                                  weekday().toDate(
+                                    Intl.DateTimeFormat().resolvedOptions()
+                                      .timeZone,
+                                  ),
+                                )}
                               </Calendar.HeadCell>
                             )}
                           </Index>
@@ -60,7 +74,7 @@ const CalendarExample: VoidComponent = () => {
                                       month={month().month}
                                       class="inline-flex size-8 items-center justify-center rounded-md text-sm focus-visible:bg-corvu-200/80 disabled:pointer-events-none data-today:bg-corvu-200/50 data-range-start:bg-corvu-300 data-range-end:bg-corvu-300 lg:hover:not-data-range-start:not-data-range-end:bg-corvu-200/80"
                                     >
-                                      {day().getDate()}
+                                      {day().day}
                                     </Calendar.CellTrigger>
                                   </Calendar.Cell>
                                 )}

--- a/web/src/lib/typedoc/libraries.ts
+++ b/web/src/lib/typedoc/libraries.ts
@@ -216,6 +216,8 @@ const Calendar: Library = {
         'excludeDisabled',
         'labelIds',
         'contextId',
+        'timeZone',
+        'locale',
       ],
     },
     Label: {

--- a/web/src/lib/typedoc/resolve/lib.ts
+++ b/web/src/lib/typedoc/resolve/lib.ts
@@ -28,6 +28,8 @@ const resolveReferenceType = (
         return type.name
       case '@floating-ui/core':
         return type.name
+      case '@internationalized/date':
+        return type.name
     }
     const api = Typedoc[type.package]
     const declaration = findDeclarationByName(api.name, api.children)

--- a/web/src/lib/typedoc/types/typedoc.ts
+++ b/web/src/lib/typedoc/types/typedoc.ts
@@ -163,6 +163,7 @@ export type ReferenceType = {
     | '@floating-ui/dom'
     | '@floating-ui/core'
     | 'corvu'
+    | '@internationalized/date'
 }
 
 export type LiteralType = {


### PR DESCRIPTION
I needed this feature for a project I'm working on, so I made the PR. 
I'm totally if this is not merged.

I'm willing to help maintain it as well since I'm using it in a project as well.
We can make it so the user facing APIs use `Date` object instead of `DateValue`, if that'll help this PR merge.